### PR TITLE
rename package name to comply with the starndards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "React development seed",
+    "name": "react-development-seed",
     "version": "1.0.0",
     "description": "",
     "main": "index.js",


### PR DESCRIPTION
* npm install fails due to naming conventions
see -> https://docs.npmjs.com/files/package.json#name
```
Therefore, the name can't contain any non-URL-safe characters
```